### PR TITLE
Add msb user to custom sudoers for reboot

### DIFF
--- a/meta-microservicebus-node/recipes-microservicebus-node/microservicebus-node-user/files/microservicebus-node-sudoers
+++ b/meta-microservicebus-node/recipes-microservicebus-node/microservicebus-node-user/files/microservicebus-node-sudoers
@@ -1,0 +1,3 @@
+## microServiceBus user group is allowed to execute reboot
+
+%@MSB_NODE_GROUP@ ALL=NOPASSWD: /sbin/reboot

--- a/meta-microservicebus-node/recipes-microservicebus-node/microservicebus-node-user/microservicebus-node-user_1.1.0.bb
+++ b/meta-microservicebus-node/recipes-microservicebus-node/microservicebus-node-user/microservicebus-node-user_1.1.0.bb
@@ -4,8 +4,13 @@ DESCRIPTION = "Create user for microservicebus-node"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 
+# Sudoers file for microservicebus user group
+SRC_URI += "file://microservicebus-node-sudoers"
+
 # Name of user for microServicebus
 MSB_NODE_USER ?= "msb"
+# Name of user group for microServicebus
+MSB_NODE_GROUP ?= "msb"
 # Specify home directory for msb user, default empty meaning it will be set to default for useradd
 MSB_HOME_DIR_PATH ?= ""
 # Specify users groups
@@ -28,11 +33,16 @@ MSB_CREATE_HOME = "${@oe.utils.conditional('MSB_HOME_DIR_PATH', '', '-m', '-M -d
 USERADD_PARAM_${PN} = "-u 1200 -c microServiceBus ${MSB_CREATE_HOME} -U -G ${MSB_USER_GROUPS} -r -s /bin/nologin ${MSB_NODE_USER}"
 
 do_install () {
-	install -d -m 755 ${D}${datadir}/${MSB_NODE_USER}
-	chown -R ${MSB_NODE_USER} ${D}${datadir}/${MSB_NODE_USER}
+
+	# Replace microservicebus parameters
+	sed -i -e 's:@MSB_NODE_GROUP@:${MSB_NODE_GROUP}:g' ${WORKDIR}/microservicebus-node-sudoers
+
+	# Install sudoers file
+	install -d ${D}${sysconfdir}/sudoers.d/
+	install -m 0644 ${WORKDIR}/microservicebus-node-sudoers ${D}${sysconfdir}/sudoers.d/
 }
 
-FILES_${PN} = "${datadir}/${MSB_NODE_USER}"
+FILES_${PN} = "${sysconfdir}/sudoers.d/"
 
 # Prevents do_package failures with:
 # debugsources.list: No such file or directory:


### PR DESCRIPTION
Fix bug that microservicebus-core not having sufficient permissions to reboot the device, this made the firmware update to fail because it relies om reboot after install.