### PR TITLE
Add IoT Edge support

### DIFF
--- a/meta-microservicebus-raspberrypi/conf/bblayers.conf.sample
+++ b/meta-microservicebus-raspberrypi/conf/bblayers.conf.sample
@@ -6,16 +6,16 @@ BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 
 BBLAYERS ?= " \
-  /home/yocto/yocto/source/poky/meta \
-  /home/yocto/yocto/source/poky/meta-poky \
-  /home/yocto/yocto/source/poky/meta-yocto-bsp \
-  /home/yocto/yocto/source/meta-openembedded/meta-oe \
-  /home/yocto/yocto/source/meta-openembedded/meta-filesystems \
-  /home/yocto/yocto/source/meta-openembedded/meta-networking \
-  /home/yocto/yocto/source/meta-openembedded/meta-python \
-  /home/yocto/yocto/source/meta-microservicebus/meta-microservicebus-node \
-  /home/yocto/yocto/source/meta-microservicebus/meta-microservicebus-raspberrypi \
-  /home/yocto/yocto/source/meta-raspberrypi \
-  /home/yocto/yocto/source/meta-rauc \
+  ${TOPDIR}/../meta \
+  ${TOPDIR}/../meta-poky \
+  ${TOPDIR}/../meta-yocto-bsp \
+  ${TOPDIR}/../meta-openembedded/meta-oe \
+  ${TOPDIR}/../meta-openembedded/meta-filesystems \
+  ${TOPDIR}/../meta-openembedded/meta-networking \
+  ${TOPDIR}/../meta-openembedded/meta-python \
+  ${TOPDIR}/../meta-microservicebus/meta-microservicebus-node \
+  ${TOPDIR}/../meta-microservicebus/meta-microservicebus-raspberrypi \
+  ${TOPDIR}/../meta-raspberrypi \
+  ${TOPDIR}/../meta-rauc \
   "
   

--- a/meta-microservicebus-raspberrypi/conf/bblayers.conf.sample
+++ b/meta-microservicebus-raspberrypi/conf/bblayers.conf.sample
@@ -17,5 +17,8 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-microservicebus/meta-microservicebus-raspberrypi \
   ${TOPDIR}/../meta-raspberrypi \
   ${TOPDIR}/../meta-rauc \
+  ${TOPDIR}/../meta-rust \
+  ${TOPDIR}/../meta-virtualization \
+  ${TOPDIR}/../meta-iotedge \
   "
   

--- a/meta-microservicebus-raspberrypi/conf/bblayers.conf.sample
+++ b/meta-microservicebus-raspberrypi/conf/bblayers.conf.sample
@@ -1,0 +1,21 @@
+# POKY_BBLAYERS_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+POKY_BBLAYERS_CONF_VERSION = "2"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS ?= " \
+  /home/yocto/yocto/source/poky/meta \
+  /home/yocto/yocto/source/poky/meta-poky \
+  /home/yocto/yocto/source/poky/meta-yocto-bsp \
+  /home/yocto/yocto/source/meta-openembedded/meta-oe \
+  /home/yocto/yocto/source/meta-openembedded/meta-filesystems \
+  /home/yocto/yocto/source/meta-openembedded/meta-networking \
+  /home/yocto/yocto/source/meta-openembedded/meta-python \
+  /home/yocto/yocto/source/meta-microservicebus/meta-microservicebus-node \
+  /home/yocto/yocto/source/meta-microservicebus/meta-microservicebus-raspberrypi \
+  /home/yocto/yocto/source/meta-raspberrypi \
+  /home/yocto/yocto/source/meta-rauc \
+  "
+  

--- a/meta-microservicebus-raspberrypi/conf/bblayers.conf.sample
+++ b/meta-microservicebus-raspberrypi/conf/bblayers.conf.sample
@@ -17,8 +17,5 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-microservicebus/meta-microservicebus-raspberrypi \
   ${TOPDIR}/../meta-raspberrypi \
   ${TOPDIR}/../meta-rauc \
-  ${TOPDIR}/../meta-rust \
-  ${TOPDIR}/../meta-virtualization \
-  ${TOPDIR}/../meta-iotedge \
   "
   

--- a/meta-microservicebus-raspberrypi/conf/local.conf.sample
+++ b/meta-microservicebus-raspberrypi/conf/local.conf.sample
@@ -1,0 +1,52 @@
+MACHINE = "raspberrypi3"
+
+DISTRO ?= "poky"
+
+IMAGE_FSTYPES = "tar.bz2 ext4 rpi-sdimg"
+
+SDIMG_ROOTFS_TYPE = "ext4"
+
+DISTRO_FEATURES_append = " systemd"
+DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit"
+VIRTUAL-RUNTIME_init_manager = "systemd"
+VIRTUAL-RUNTIME_initscripts = "systemd-compat-units"
+
+PACKAGE_CLASSES ?= "package_deb"
+
+#EXTRA_IMAGE_FEATURES += " debug-tweaks"
+
+USER_CLASSES ?= "buildstats image-mklibs image-prelink"
+
+PATCHRESOLVE = "noop"
+
+BB_DISKMON_DIRS ??= "\
+    STOPTASKS,${TMPDIR},1G,100K \
+    STOPTASKS,${DL_DIR},1G,100K \
+    STOPTASKS,${SSTATE_DIR},1G,100K \
+    STOPTASKS,/tmp,100M,100K \
+    ABORT,${TMPDIR},100M,1K \
+    ABORT,${DL_DIR},100M,1K \
+    ABORT,${SSTATE_DIR},100M,1K \
+    ABORT,/tmp,10M,1K"
+
+PACKAGECONFIG_append_pn-qemu-native = " sdl"
+
+PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
+
+CONF_VERSION = "1"
+
+RPI_USE_U_BOOT = "1"
+
+SERIAL_CONSOLE = ""
+
+# Specify user for microservicebus-node
+MSB_NODE_USER = "msb"
+MSB_NODE_GROUP = "msb"
+MSB_NODE_ARG = "-w"
+
+# Specify home directory for msb user.
+MSB_HOME_DIR_PATH = "/data/home/${MSB_NODE_USER}"
+
+# Specify default SSID and password for WiFi
+RPI_WIFI_SSID = "SSID"
+RPI_WIFI_PSK = "PASSW"

--- a/meta-microservicebus-raspberrypi/conf/local.conf.sample
+++ b/meta-microservicebus-raspberrypi/conf/local.conf.sample
@@ -64,16 +64,3 @@ MSB_HOME_DIR_PATH = "/data/home/${MSB_NODE_USER}"
 RPI_WIFI_SSID = "SSID"
 RPI_WIFI_PSK = "PASSW"
 
-# Uncomment setting below to add support for Azure IoT-Edge
-#DISTRO_FEATURES_append = " virtualization"
-
-# Workaround as IoT-Edge not support latest rust version in meta-rust
-#PREFERRED_VERSION_rust = "1.34.2"
-#PREFERRED_VERSION_rust-native = "1.34.2"
-#PREFERRED_VERSION_cargo = "1.34.2"
-#PREFERRED_VERSION_cargo-native = "1.34.2"
-#PREFERRED_VERSION_libstd-rs = "1.34.2"
-#PREFERRED_VERSION_rust-cross = "1.34.2"
-#PREFERRED_VERSION_rust-llvm = "1.34.2"
-#PREFERRED_VERSION_rust-llvm-native = "1.34.2"
-

--- a/meta-microservicebus-raspberrypi/conf/local.conf.sample
+++ b/meta-microservicebus-raspberrypi/conf/local.conf.sample
@@ -53,3 +53,17 @@ MSB_HOME_DIR_PATH = "/data/home/${MSB_NODE_USER}"
 # Specify default SSID and password for WiFi
 RPI_WIFI_SSID = "SSID"
 RPI_WIFI_PSK = "PASSW"
+
+# Uncomment setting below to add support for Azure IoT-Edge
+#DISTRO_FEATURES_append = " virtualization"
+
+# Workaround as IoT-Edge not support latest rust version in meta-rust
+#PREFERRED_VERSION_rust = "1.34.2"
+#PREFERRED_VERSION_rust-native = "1.34.2"
+#PREFERRED_VERSION_cargo = "1.34.2"
+#PREFERRED_VERSION_cargo-native = "1.34.2"
+#PREFERRED_VERSION_libstd-rs = "1.34.2"
+#PREFERRED_VERSION_rust-cross = "1.34.2"
+#PREFERRED_VERSION_rust-llvm = "1.34.2"
+#PREFERRED_VERSION_rust-llvm-native = "1.34.2"
+

--- a/meta-microservicebus-raspberrypi/conf/local.conf.sample
+++ b/meta-microservicebus-raspberrypi/conf/local.conf.sample
@@ -13,7 +13,7 @@ VIRTUAL-RUNTIME_initscripts = "systemd-compat-units"
 
 PACKAGE_CLASSES ?= "package_deb"
 
-#EXTRA_IMAGE_FEATURES += " debug-tweaks"
+EXTRA_IMAGE_FEATURES += " debug-tweaks"
 
 USER_CLASSES ?= "buildstats image-mklibs image-prelink"
 

--- a/meta-microservicebus-raspberrypi/conf/local.conf.sample
+++ b/meta-microservicebus-raspberrypi/conf/local.conf.sample
@@ -1,4 +1,4 @@
-MACHINE = "raspberrypi3"
+MACHINE ?= "raspberrypi3"
 
 DISTRO ?= "poky"
 
@@ -10,6 +10,9 @@ DISTRO_FEATURES_append = " systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 VIRTUAL-RUNTIME_initscripts = "systemd-compat-units"
+
+# Add vitualization if support for containers is needed(iot-edge)
+DISTRO_FEATURES_append = " virtualization"
 
 PACKAGE_CLASSES ?= "package_deb"
 

--- a/meta-microservicebus-raspberrypi/conf/local.conf.sample
+++ b/meta-microservicebus-raspberrypi/conf/local.conf.sample
@@ -1,23 +1,33 @@
+# An sample config to build an RPi image supporting microServiceBus and
+# firmware update using RAUC
+
+CONF_VERSION = "1"
+
+# Default to build for RPi 3
 MACHINE ?= "raspberrypi3"
 
+# Use poky as distro
 DISTRO ?= "poky"
 
+# Create an rpi-sdimg for writing to SD-Card
 IMAGE_FSTYPES = "tar.bz2 ext4 rpi-sdimg"
 
+# Use ext4 as rootfs as that is supported by RAUC
 SDIMG_ROOTFS_TYPE = "ext4"
 
+# Set systemd as init and daemon manager
 DISTRO_FEATURES_append = " systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 VIRTUAL-RUNTIME_initscripts = "systemd-compat-units"
 
-# Add vitualization if support for containers is needed(iot-edge)
-DISTRO_FEATURES_append = " virtualization"
-
+# Debian package format for packages
 PACKAGE_CLASSES ?= "package_deb"
 
-EXTRA_IMAGE_FEATURES += " debug-tweaks"
+# Uncomment debug-tweaks below to add support for blank root password
+#EXTRA_IMAGE_FEATURES += " debug-tweaks"
 
+# Some default Yocto settings
 USER_CLASSES ?= "buildstats image-mklibs image-prelink"
 
 PATCHRESOLVE = "noop"
@@ -36,10 +46,10 @@ PACKAGECONFIG_append_pn-qemu-native = " sdl"
 
 PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
 
-CONF_VERSION = "1"
-
+# Use U-Boot as bootloader to support RAUC firmware updates
 RPI_USE_U_BOOT = "1"
 
+# Set serial console
 SERIAL_CONSOLE = ""
 
 # Specify user for microservicebus-node

--- a/meta-microservicebus-raspberrypi/recipes-core/images/msb-image-iot-edge.bb
+++ b/meta-microservicebus-raspberrypi/recipes-core/images/msb-image-iot-edge.bb
@@ -1,0 +1,46 @@
+# Base this image on core-image-base
+require recipes-core/images/core-image-base.bb
+
+# Base configuration for msb-images
+
+# Run ssh server default
+EXTRA_IMAGE_FEATURES += " ssh-server-openssh"
+
+# Use u-boot as second bootloader, to enable dual boot
+RPI_USE_U_BOOT = "1"
+
+# Set fixed size rootf to not break rauc update
+IMAGE_ROOTFS_EXTRA_SPACE = "0"
+IMAGE_ROOTFS_SIZE = "1048576"
+
+# Rauc to install firmware update, need u-boot-fw-utils
+# to set u-boot env. from user space to switch slots
+IMAGE_INSTALL_append = " rauc"
+IMAGE_INSTALL_append = " u-boot-fw-utils"
+
+# Wifi support
+DISTRO_FEATURES_append = " wifi"
+IMAGE_INSTALL_append = " iw wpa-supplicant"
+
+# Basic microservicebus
+IMAGE_INSTALL_append = " \
+    "
+# Enable init script to prepare wifi, ssh, data partition.
+# Add resize2fs to be able to use all off sd-card
+IMAGE_INSTALL_append = " \
+    rpi-init \
+    e2fsprogs-resize2fs \
+    "
+    
+#IoT Edge ???
+DISTRO_FEATURES_append += " virtualization"
+IMAGE_INSTALL_append = "\
+    libiothsm-std \
+    iotedge-cli \
+    iotedge-daemon \
+    "
+
+# Add raspberry pi firmware
+RRECOMMENDS_${PN} = "\
+    ${MACHINE_EXTRA_RRECOMMENDS} \
+"

--- a/meta-microservicebus-raspberrypi/recipes-core/images/msb-image-iot-edge.bb
+++ b/meta-microservicebus-raspberrypi/recipes-core/images/msb-image-iot-edge.bb
@@ -1,7 +1,7 @@
 # Base this image on core-image-base
 require recipes-core/images/core-image-base.bb
 
-# Base configuration for msb-images
+# This configuration is to run mSB-node inside Azure IoT-Edge container 
 
 # Run ssh server default
 EXTRA_IMAGE_FEATURES += " ssh-server-openssh"
@@ -11,7 +11,12 @@ RPI_USE_U_BOOT = "1"
 
 # Set fixed size rootf to not break rauc update
 IMAGE_ROOTFS_EXTRA_SPACE = "0"
-IMAGE_ROOTFS_SIZE = "1048576"
+IMAGE_ROOTFS_SIZE = "4194304"
+
+# Add raspberry pi firmware
+RRECOMMENDS_${PN} = "\
+    ${MACHINE_EXTRA_RRECOMMENDS} \
+"
 
 # Rauc to install firmware update, need u-boot-fw-utils
 # to set u-boot env. from user space to switch slots
@@ -32,15 +37,24 @@ IMAGE_INSTALL_append = " \
     e2fsprogs-resize2fs \
     "
     
-#IoT Edge ???
-DISTRO_FEATURES_append += " virtualization"
+#Azure IoT Edge
 IMAGE_INSTALL_append = "\
     libiothsm-std \
     iotedge-cli \
     iotedge-daemon \
     "
 
-# Add raspberry pi firmware
-RRECOMMENDS_${PN} = "\
-    ${MACHINE_EXTRA_RRECOMMENDS} \
-"
+# The setting below needs to be added to local.conf or distro, this is only as template 
+#DISTRO_FEATURES_append = " virtualization"
+
+# Workaround as IoT-Edge not support latest rust version in meta-rust
+#PREFERRED_VERSION_rust = "1.34.2"
+#PREFERRED_VERSION_rust-native = "1.34.2"
+#PREFERRED_VERSION_cargo = "1.34.2"
+#PREFERRED_VERSION_cargo-native = "1.34.2"
+#PREFERRED_VERSION_libstd-rs = "1.34.2"
+#PREFERRED_VERSION_rust-cross = "1.34.2"
+#PREFERRED_VERSION_rust-llvm = "1.34.2"
+#PREFERRED_VERSION_rust-llvm-native = "1.34.2"
+
+


### PR DESCRIPTION
Add local.conf sample and bblayers sample for basic build.
Add image recipe for building RPI with Azure IoT-Edge, this to enable support to run
mSB-node in an container.