### PR TITLE
Add support for NODE_EXTRA_CA_CERT to mSB-node service

### DIFF
--- a/meta-microservicebus-node/recipes-microservicebus-node/microservicebus-node-service/files/microservicebus-node.service
+++ b/meta-microservicebus-node/recipes-microservicebus-node/microservicebus-node-service/files/microservicebus-node.service
@@ -15,7 +15,7 @@ Environment=NODE_ENV=production
 Environment=MSB_PLATFORM=YOCTO
 Environment=MSB_HOST=@MSB_NODE_HOST@
 Environment=DAM_SOCKETPATH=@MSB_DAM_SOCKETPATH@
-
+Environment=NODE_EXTRA_CA_CERTS=@MSB_NODE_EXTRA_CA_CERTS@
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-microservicebus-node/recipes-microservicebus-node/microservicebus-node-service/microservicebus-node-service_2.4.0.bb
+++ b/meta-microservicebus-node/recipes-microservicebus-node/microservicebus-node-service/microservicebus-node-service_2.4.0.bb
@@ -23,6 +23,7 @@ MSB_NODE_USER ?= "msb"
 MSB_NODE_GROUP ?= "msb"
 MSB_NODE_HOST ?= "microservicebus.com"
 MSB_DAM_SOCKETPATH ?= "/var/run/dam"
+MSB_NODE_EXTRA_CA_CERTS ?= ""
 
 do_install() {
              
@@ -33,6 +34,7 @@ do_install() {
     sed -i -e 's:@MSB_NODE_GROUP@:${MSB_NODE_GROUP}:g' ${WORKDIR}/microservicebus-node.service
     sed -i -e 's:@MSB_NODE_HOST@:${MSB_NODE_HOST}:g' ${WORKDIR}/microservicebus-node.service
     sed -i -e 's:@MSB_DAM_SOCKETPATH@:${MSB_DAM_SOCKETPATH}:g' ${WORKDIR}/microservicebus-node.service
+    sed -i -e 's:@MSB_NODE_EXTRA_CA_CERTS@:${MSB_NODE_EXTRA_CA_CERTS}:g' ${WORKDIR}/microservicebus-node.service
 
     #Install service file
     install -d ${D}${systemd_system_unitdir}
@@ -44,3 +46,4 @@ do_install() {
 }
 
 REQUIRED_DISTRO_FEATURES= "systemd"
+


### PR DESCRIPTION
This adds the posibility to point to custom CA, for example if mSB
is running behind a proxy.
In local.conf set MSB_NODE_EXTRA_CA_CERTS = "PATH-TO-CA.crt"